### PR TITLE
Use a file for SQLite persistence when running locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# SQLite data lives here
+data/

--- a/internal/persistence/sqlite/sqlite.go
+++ b/internal/persistence/sqlite/sqlite.go
@@ -2,8 +2,19 @@ package sqlite
 
 import (
 	"database/sql"
+	"os"
+	"path/filepath"
 )
 
 func NewInMemory() (*sql.DB, error) {
 	return sql.Open("libsql", "file::memory:")
+}
+
+func NewFromFile(path string) (*sql.DB, error) {
+	err := os.MkdirAll(filepath.Dir(path), os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+
+	return sql.Open("libsql", "file:"+path)
 }


### PR DESCRIPTION
This PR changes the default behavior of the locally-running server such that the SQLite database is opened with a backing file instead of using an in-memory database.

This improves the development experience; when developing UIs, new data doesn't have to be seeded with every restart of the server.